### PR TITLE
Added mechanism to store intitial layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ const APICallEffectHandler = ((handlers) => {
 
 const Reduction = record({
   appState: fromJS({
+    initialLayout: null,
     layout: null,
     loading: false,
   }),
@@ -63,7 +64,6 @@ export class App extends Component {
       dispatcher,
       reduction: new Reduction(),
       actionLog: List.of(),
-      layout: null,
     };
 
     // if hot-module-reload, replay state after file save.
@@ -87,14 +87,18 @@ export class App extends Component {
   }
 
   render() {
-    if (this.state.reduction.getIn(['appState', 'loading']) && !this.state.reduction.getIn(['appState', 'layout'])) {
+    const initialLayout = this.state.reduction.getIn(['appState', 'initialLayout']);
+    const stateLayout = this.state.reduction.getIn(['appState', 'layout']);
+    const layout = stateLayout ? stateLayout : initialLayout;
+
+    if (this.state.reduction.getIn(['appState', 'loading']) && !layout) {
       return <p>Loading</p>;
     }
 
     return (
       <div>
         <BoardView dispatcher={this.state.dispatcher}
-                    layout={this.state.reduction.getIn(['appState', 'layout'])}/>
+            layout={layout}/>
       </div>
     );
   }

--- a/src/reducers/boardReducer.js
+++ b/src/reducers/boardReducer.js
@@ -13,5 +13,5 @@ export const layoutFetchRequested = (reduction, payload) => {
 
 export const layoutFetched = (reduction, payload) => {
   return reduction
-    .setIn(['appState', 'layout'], fromJS(payload));
+    .setIn(['appState', 'initialLayout'], fromJS(payload));
 };

--- a/src/reducers/firebaseReducer.js
+++ b/src/reducers/firebaseReducer.js
@@ -1,21 +1,10 @@
 import { fromJS } from 'immutable';
 
 const updateLayout = (layout, task) => {
-  const isPresent = (tasks, innerTask) => {
-    for (let idx = 0; idx < tasks.length; idx++) {
-      if (tasks[idx].content === innerTask.content) {
-        return true;
-      }
-    }
-    return false;
-  };
-
   const updateRow = (row) => {
     if (row.id === task.sectionId) {
       row.tasks = row.tasks || [];
-      if (!isPresent(row.tasks, task)) {
-        row.tasks.push(task);
-      }
+      row.tasks.push(task);
     }
     return row;
   };
@@ -34,14 +23,14 @@ const updateLayout = (layout, task) => {
   });
 };
 
-
 export const tasksReceived = (reduction, payload) => {
-  const layout = reduction.getIn(['appState', 'layout']).toJS();
+  const layout = reduction.getIn(['appState', 'initialLayout']).toJS();
 
+  // put tasks into initialLayout
   Object.keys(payload).forEach(key => {
     updateLayout(layout, payload[key]);
   });
 
-  layout.updated = true;
-  return reduction.setIn(['appState', 'layout'], fromJS(layout));
+  return reduction
+    .setIn(['appState', 'layout'], fromJS(layout));
 };


### PR DESCRIPTION
* when tasks arrive, re-use everytime initial layout and just put them
* on the right sectionId, old tasks aren't used so no cleanup is required.
* removed isPresent check, because initial layout has no tasks